### PR TITLE
feat: in-buffer markdown rendering in nvim (render-markdown.nvim)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `nvim/init.lua`: in-buffer markdown rendering via
+  `MeanderingProgrammer/render-markdown.nvim` (lazy-loaded on `ft=markdown`).
+  Prettifies markdown live in the terminal — heading icons/backgrounds, list
+  bullets, checkboxes, code-block backgrounds, aligned tables, and concealed
+  inline markup — un-rendering the line under the cursor while editing. Adds the
+  `markdown_inline` treesitter parser (needed for inline elements) and a
+  `<leader>tm` toggle (`:RenderMarkdown toggle`). LaTeX math support is disabled
+  (avoids a checkhealth warning; needs extra CLIs). Icons use the existing
+  `nvim-web-devicons`; no browser required, so it works over SSH.
+
 ## [1.7.1] - 2026-06-28
 
 ### Fixed

--- a/nvim/.config/nvim/init.lua
+++ b/nvim/.config/nvim/init.lua
@@ -240,7 +240,7 @@ require('lazy').setup({
       -- Ensure parsers are present on fresh installs (async, no-op if already installed).
       require('nvim-treesitter').install({
         'bash', 'c', 'cpp', 'css', 'go', 'html', 'javascript',
-        'json', 'lua', 'markdown', 'python', 'rust', 'toml',
+        'json', 'lua', 'markdown', 'markdown_inline', 'python', 'rust', 'toml',
         'typescript', 'vim', 'yaml',
       })
 
@@ -552,6 +552,32 @@ require('lazy').setup({
     dependencies = { 'folke/twilight.nvim' },
     opts         = { plugins = { twilight = { enabled = true } } },
     keys         = { { '<leader>z', '<cmd>ZenMode<CR>', desc = 'Zen mode' } },
+  },
+
+  -- ── Markdown rendering ─────────────────────────────────────────────────────
+  -- In-buffer prettified markdown: heading icons/backgrounds, list bullets,
+  -- checkboxes, code-block backgrounds, aligned tables, and concealed inline
+  -- markup (**, `, links). Terminal-native — no browser, works over SSH. The line
+  -- under the cursor un-renders in insert mode so editing stays unobstructed.
+  -- Needs the markdown + markdown_inline treesitter parsers (installed above).
+  {
+    'MeanderingProgrammer/render-markdown.nvim',
+    cond         = vim.fn.has('nvim-0.10') == 1, -- renders via extmarks (nvim 0.10+)
+    ft           = { 'markdown' },
+    dependencies = {
+      'nvim-treesitter/nvim-treesitter', -- markdown + markdown_inline parsers
+      'nvim-tree/nvim-web-devicons',     -- code-block language icons
+    },
+    opts         = {
+      -- Defaults are well-tuned; render is on by default. LaTeX math rendering
+      -- needs the `latex` parser + utftex/latex2text CLIs (not installed), so
+      -- disable it to avoid a checkhealth warning and stray `$…$` processing.
+      -- Re-enable + install those tools if you want inline math.
+      latex = { enabled = false },
+    },
+    keys         = {
+      { '<leader>tm', '<cmd>RenderMarkdown toggle<CR>', desc = 'Toggle markdown render' },
+    },
   },
   -- ── Motion ───────────────────────────────────────────────────────────────
   {


### PR DESCRIPTION
## Summary
Adds terminal-native, in-buffer markdown rendering so `.md` files look nice directly in nvim — no browser (works over SSH / on GPU servers / in containers).

- **Plugin:** `MeanderingProgrammer/render-markdown.nvim`, lazy-loaded on `ft=markdown`.
- Renders heading icons/backgrounds, list bullets, checkboxes, code-block backgrounds, aligned tables, and conceals inline markup (`**`, `` ` ``, links). The line under the cursor un-renders in insert mode so editing stays unobstructed.
- Adds the **`markdown_inline`** treesitter parser (required for inline elements) next to the existing `markdown`.
- Icons reuse the existing `nvim-web-devicons`; no new icon dependency.
- **LaTeX math disabled** — it needs the `latex` parser + `utftex`/`latex2text` CLIs (not installed); disabling avoids a checkhealth warning and stray `$…$` processing. Re-enable + install those tools for inline math.
- **`<leader>tm`** toggles rendering (`:RenderMarkdown toggle`).

## Test plan
- [x] `nvim --headless` loads config cleanly (exit 0)
- [x] `Lazy sync` installs the plugin; `markdown` + `markdown_inline` parsers present (`.so` on disk)
- [x] Opening a `.md` buffer: plugin loads, `:RenderMarkdown` exists, `state.enabled = true`, parser attaches
- [x] `:checkhealth render-markdown` → all ✅, **0 warnings / 0 errors** (LaTeX warning gone after disabling)
- [x] `bash test.sh workstation` → 46/46 (no regression)

## Note
Independent of #38 (diff navigation); touches non-overlapping sections of `init.lua`, so no merge conflict.