### PR TITLE
feat: add $HOME/go/bin to PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `zsh/.zshrc`: prepend `$HOME/go/bin` to `PATH` so `go install`-ed binaries are
+  found (no-op when the directory doesn't exist).
+
 ## [1.8.0] - 2026-07-04
 
 ### Added

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -4,7 +4,7 @@ if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]
 fi
 
 # ── PATH ──────────────────────────────────────────────────────────────────────
-export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
+export PATH="$HOME/go/bin:$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
 
 # ── History ───────────────────────────────────────────────────────────────────
 HISTSIZE=1000000


### PR DESCRIPTION
Prepend `$HOME/go/bin` to `PATH` in `zsh/.zshrc` so `go install`-ed binaries are on PATH (no-op when the dir doesn't exist).

Salvaged from a stale autostash (2026-05-03) during stash cleanup; the rest of that stash was redundant with master and dropped.